### PR TITLE
contracts: fix compile warnings

### DIFF
--- a/contracts/manifests/base/contracts/buildings_systems.toml
+++ b/contracts/manifests/base/contracts/buildings_systems.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x389abe222e817088adf097fb6b6bae924eee2b3a9dae88b0a0f2627512a14d3"
+class_hash = "0x1ea75213d31c666460b6b84bc87135239df5da93f674bc9675cb68d409b430c"
 abi = "abis/base/contracts/buildings_systems.json"
 reads = []
 writes = []

--- a/contracts/manifests/base/contracts/combat_systems.toml
+++ b/contracts/manifests/base/contracts/combat_systems.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x6b6dccfebbde759f26ae738d758e1fab97c53309b880e010b4af90e1985b657"
+class_hash = "0x458b477b3b29e46652c9fed7d2c6d36eac2cadf155b051ba374d13e9cf92a01"
 abi = "abis/base/contracts/combat_systems.json"
 reads = []
 writes = []

--- a/contracts/manifests/base/contracts/config_systems.toml
+++ b/contracts/manifests/base/contracts/config_systems.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x2d7e9b4cc4843bc6510a7142c3a12eba1c398c1e6662a3694731e3bdd0c27c4"
+class_hash = "0x1734fd268fca6a343e7751adf138e30d36865d8a5e4a3c67d9692b7c02cda6a"
 abi = "abis/base/contracts/config_systems.json"
 reads = []
 writes = []

--- a/contracts/manifests/base/contracts/labor_systems.toml
+++ b/contracts/manifests/base/contracts/labor_systems.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x47f6df3f110faa3db948702713ce075d69328fd976a0b6c053d02bbda054406"
+class_hash = "0x75d008d8780b27a9c93ccebb4d76ccb8f99cb4dc74aaa542c8c399dd0ac93c6"
 abi = "abis/base/contracts/labor_systems.json"
 reads = []
 writes = []

--- a/contracts/src/models/position.cairo
+++ b/contracts/src/models/position.cairo
@@ -188,7 +188,6 @@ trait TravelTrait<T> {
 impl TravelImpl<T, +Into<T, Cube>, +Copy<T>, +Drop<T>> of TravelTrait<T> {
 
     fn calculate_distance(self: T, destination: T) -> u128 {
-        let cube: Cube = self.into();
        CubeImpl::distance(self.into(), destination.into())
     }
 

--- a/contracts/src/models/resources.cairo
+++ b/contracts/src/models/resources.cairo
@@ -204,7 +204,6 @@ impl OwnedResourcesTrackerImpl of OwnedResourcesTrackerTrait {
 
             let (resource_type, probability) = *zipped.at(index);
             if self.owns_resource_type(resource_type) {
-                let rcd = (*self).resource_types;
                 owned_resource_types.append(resource_type);
                 owned_resource_probabilities.append(probability);
             }

--- a/contracts/src/models/road.cairo
+++ b/contracts/src/models/road.cairo
@@ -69,7 +69,7 @@ mod tests {
     fn test_get_road() {
         let world = spawn_eternum();
 
-        starknet::testing::set_contract_address(world.executor());
+        
         let start_coord = Coord { x: 20, y: 30};
         let end_coord = Coord { x: 40, y: 50};
         let usage_count = 44;

--- a/contracts/src/systems/bank/contracts.cairo
+++ b/contracts/src/systems/bank/contracts.cairo
@@ -23,7 +23,7 @@ mod bank_systems {
     use cubit::f128::types::fixed::{Fixed, FixedTrait};
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl BankSystemsImpl of IBankSystems<ContractState> {
 
         fn swap(
@@ -53,7 +53,6 @@ mod bank_systems {
             let mut bank_auction_time_since_start_fixed 
                 = bank_auction.get_time_since_start_fixed();
 
-            let zero_fixed = Fixed {sign: false, mag: 0};
             let swap_cost_resources 
                 = get!(world, (bought_resource_type, bank_swap_resource_cost_index), BankSwapResourceCost);
 

--- a/contracts/src/systems/bank/tests.cairo
+++ b/contracts/src/systems/bank/tests.cairo
@@ -91,7 +91,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, IBankSystemsDispatcher,) {
 
     // create caravan for swap
 
-    starknet::testing::set_contract_address(world.executor());
+    
     let transport_id = 44;
     set!(world, (
         Owner {
@@ -260,7 +260,7 @@ fn test_bank_swap__wrong_caller() {
 fn test_bank_swap__wrong_transport_position() {
     let (world, bank_id, transport_id, bank_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Position {
             entity_id: transport_id,
@@ -287,7 +287,7 @@ fn test_bank_swap__wrong_transport_position() {
 fn test_bank_swap__wrong_transport_arrival_time() {
     let (world, bank_id, transport_id, bank_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         ArrivalTime {
             entity_id: transport_id,

--- a/contracts/src/systems/buildings/contracts.cairo
+++ b/contracts/src/systems/buildings/contracts.cairo
@@ -10,7 +10,7 @@ mod buildings_systems {
     use eternum::models::config::{LaborBuildingsConfig, LaborBuildingCost};
     use eternum::models::resources::{Resource, ResourceTrait, ResourceCost};
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl BuildingsSystemsImpl of IBuildingsSystems<ContractState> {
         fn create(
             self: @ContractState, world: IWorldDispatcher, realm_entity_id: u128, building_type: u8
@@ -22,7 +22,6 @@ mod buildings_systems {
             // assert building type is between 1 and 4 (inclusive)
             assert(building_type >= 1 && building_type <= 4, 'invalid building type');
 
-            let building = get!(world, (realm_entity_id), LaborBuilding);
 
             // remove the cost from the realm balance
             let buildings_cost: LaborBuildingCost = get!(

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -78,7 +78,7 @@ use eternum::alias::ID;
 
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl SoldierSystemsImpl of ISoldierSystems<ContractState> {
         /// Create a raider unit for a realm
         /// 
@@ -411,8 +411,6 @@ use eternum::alias::ID;
             let mut merge_into_unit_quantity = get!(world, merge_into_unit_id, Quantity);
 
             let merge_into_unit_position = get!(world, merge_into_unit_id, Position);
-
-            let mut added_inventory_items: Array<u128> = array![];
             
             let mut index = 0; 
             loop {
@@ -574,7 +572,7 @@ use eternum::alias::ID;
 
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CombatSystemsImpl of ICombatSystems<ContractState> {
 
         /// Attack an entity
@@ -802,7 +800,6 @@ use eternum::alias::ID;
             
 
             let mut attacker_attack = get!(world, attacker_id, Attack);
-            let mut attacker_defence = get!(world, attacker_id, Defence);
             
 
             let target_realm_entity_id = get!(world, target_entity_id, EntityOwner).entity_owner_id;

--- a/contracts/src/systems/combat/tests/combat_attack_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/combat_attack_system_tests.cairo
@@ -141,7 +141,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
         attacker_realm_entity_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set up attacker
     set!(world, (Owner { entity_id: attacker_realm_entity_id, address: contract_address_const::<'attacker'>()}));
@@ -164,10 +164,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
     starknet::testing::set_contract_address(
         contract_address_const::<'attacker'>()
     );
-    
-    let attacker_combat = get!(world, attacker_realm_entity_id, TownWatch);
-    let attacker_town_watch_id = attacker_combat.town_watch_id;
-    
+        
 
     // buy soldiers for attacker
     let attacker_unit_id = soldier_systems_dispatcher.create_soldiers(
@@ -224,8 +221,8 @@ fn test_attack() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
     
@@ -261,8 +258,8 @@ fn test_not_owner() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
@@ -291,13 +288,13 @@ fn test_attacker_in_transit() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set arrival time a future time
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         ArrivalTime { 
             entity_id: attacker_unit_id, 
@@ -329,13 +326,13 @@ fn test_attacker_dead() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set attacker health to 0
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Health { 
             entity_id: attacker_unit_id, 
@@ -367,13 +364,13 @@ fn test_target_dead() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set target health to 0
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Health { 
             entity_id: target_town_watch_id, 
@@ -406,13 +403,13 @@ fn test_wrong_position() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id, 
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id, 
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set attacker position to a different position
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Position { 
             entity_id: attacker_unit_id, 

--- a/contracts/src/systems/combat/tests/combat_steal_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/combat_steal_system_tests.cairo
@@ -180,7 +180,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
         harbors, rivers, regions, wonder, 0, target_realm_entity_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     starknet::testing::set_block_timestamp(1000);
 
@@ -296,8 +296,6 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
         contract_address_const::<'attacker'>()
     );
 
-    let attacker_combat = get!(world, attacker_realm_entity_id, TownWatch);
-    let attacker_town_watch_id = attacker_combat.town_watch_id;
     
 
     // buy soldiers for attacker
@@ -308,7 +306,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
 
     // set attacker unit position to be at target realm
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Position { 
             entity_id: attacker_unit_id, 
@@ -373,7 +371,7 @@ fn test_steal_success() {
         combat_systems_dispatcher
     ) = setup();
     
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // make the target completely defenceless 
     // so that the attacker's victory is assured
@@ -395,7 +393,6 @@ fn test_steal_success() {
             );
 
     let attacker_unit_health = get!(world, attacker_unit_id, Health);
-    let target_unit_health = get!(world, target_town_watch_id, Health);
 
     // ensure attacker's health is intact
     assert(
@@ -485,7 +482,7 @@ fn test_steal_success_with_order_boost() {
         combat_systems_dispatcher
     ) = setup();
     
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // make the target completely defenceless 
     // so that the attacker's victory is assured
@@ -515,7 +512,6 @@ fn test_steal_success_with_order_boost() {
             );
 
     let attacker_unit_health = get!(world, attacker_unit_id, Health);
-    let target_unit_health = get!(world, target_town_watch_id, Health);
 
     // ensure attacker's health is intact
     assert(
@@ -606,8 +602,8 @@ fn test_not_owner() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id,
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id,
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
@@ -633,13 +629,13 @@ fn test_attacker_in_transit() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id,
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id,
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set arrival time a future time
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         ArrivalTime { 
             entity_id: attacker_unit_id, 
@@ -669,13 +665,13 @@ fn test_attacker_dead() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id,
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id,
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set attacker health to 0
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Health { 
             entity_id: attacker_unit_id, 
@@ -709,13 +705,13 @@ fn test_wrong_position() {
 
     let (
         world, 
-        attacker_realm_entity_id, attacker_unit_id,
-        target_realm_entity_id, target_town_watch_id, 
+        _, attacker_unit_id,
+        _, target_town_watch_id, 
         combat_systems_dispatcher
     ) = setup();
 
     // set attacker position to a different position
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Position { 
             entity_id: attacker_unit_id, 
@@ -750,7 +746,7 @@ fn test_steal_success_army_to_army() {
     let (world, attacker_realm_entity_id, attacker_unit_id, _, _ ,combat_systems_dispatcher ) 
         = setup();
     
-    starknet::testing::set_contract_address(world.executor());
+    
 
 
     let target_unit_id = 48445;

--- a/contracts/src/systems/combat/tests/soldier_create_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_create_system_tests.cairo
@@ -120,7 +120,7 @@ fn setup() -> (IWorldDispatcher, u128, ISoldierSystemsDispatcher) {
         harbors, rivers, regions, wonder, order,caller_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     
     set!(world, (Owner { entity_id: realm_entity_id, address: contract_address_const::<'caller'>()}));

--- a/contracts/src/systems/combat/tests/soldier_detach_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_detach_system_tests.cairo
@@ -117,7 +117,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
         harbors, rivers, regions, wonder, order, caller_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let caller_id = caller_realm_entity_id;
     
@@ -269,7 +269,7 @@ fn test_detach_unit() {
 #[should_panic(expected: ('not unit owner','ENTRYPOINT_FAILED' ))]
 fn test_not_owner() {
 
-    let (world, caller_id, unit_id, soldier_systems_dispatcher) 
+    let (world, _, unit_id, soldier_systems_dispatcher) 
         = setup();
 
     // set unknown caller
@@ -279,8 +279,7 @@ fn test_not_owner() {
 
     // detach 7 soldiers from unit
     let num_detached_soldiers = 7;
-    let new_unit_id 
-        = soldier_systems_dispatcher
+    soldier_systems_dispatcher
             .detach_soldiers(
                 world, unit_id, 
                 num_detached_soldiers
@@ -298,10 +297,10 @@ fn test_not_owner() {
 #[should_panic(expected: ('not enough quantity','ENTRYPOINT_FAILED' ))]
 fn test_single_soldier_detach() {
     
-        let (world, caller_id, unit_id, soldier_systems_dispatcher) 
+        let (world, _, unit_id, soldier_systems_dispatcher) 
             = setup();
 
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Quantity { 
                 entity_id: unit_id, 
@@ -317,8 +316,7 @@ fn test_single_soldier_detach() {
 
         // detach 7 soldiers from unit
         let num_detached_soldiers = 7;
-        let new_unit_id 
-            = soldier_systems_dispatcher
+        soldier_systems_dispatcher
                 .detach_soldiers(
                     world, unit_id, 
                     num_detached_soldiers
@@ -334,10 +332,10 @@ fn test_single_soldier_detach() {
 #[should_panic(expected: ('unit inventory not empty','ENTRYPOINT_FAILED' ))]
 fn test_unit_has_items_in_inventory() {
             
-    let (world, caller_id, unit_id, soldier_systems_dispatcher) 
+    let (world, _, unit_id, soldier_systems_dispatcher) 
         = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         Inventory {
             entity_id: unit_id,
@@ -353,8 +351,7 @@ fn test_unit_has_items_in_inventory() {
 
     // detach 7 soldiers from unit
     let num_detached_soldiers = 7;
-    let new_unit_id 
-        = soldier_systems_dispatcher
+    soldier_systems_dispatcher
             .detach_soldiers(
                 world, unit_id, 
                 num_detached_soldiers

--- a/contracts/src/systems/combat/tests/soldier_heal_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_heal_system_tests.cairo
@@ -120,7 +120,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
         harbors, rivers, regions, wonder, order, caller_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let caller_id = caller_realm_entity_id;
     
@@ -162,7 +162,7 @@ fn test_heal_soldier() {
 
     let (world, caller_id, new_unit_id, soldier_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // reduce the health of the first soldier by 40
 
@@ -205,7 +205,7 @@ fn test_heal_soldier() {
 #[should_panic(expected: ('not unit owner','ENTRYPOINT_FAILED' ))]
 fn test_not_unit_owner() {
 
-    let (world, caller_id, new_unit_id, soldier_systems_dispatcher) = setup();
+    let (world, _, new_unit_id, soldier_systems_dispatcher) = setup();
 
     // set unknown caller
     starknet::testing::set_contract_address(
@@ -226,7 +226,7 @@ fn test_not_unit_owner() {
 #[should_panic(expected: ('max health exceeeded','ENTRYPOINT_FAILED' ))]
 fn test_purchase_exceeds_max_health() {
 
-    let (world, caller_id, new_unit_id, soldier_systems_dispatcher) = setup();
+    let (world, _, new_unit_id, soldier_systems_dispatcher) = setup();
 
     // set unknown caller
     starknet::testing::set_contract_address(

--- a/contracts/src/systems/combat/tests/soldier_merge_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_merge_system_tests.cairo
@@ -122,7 +122,7 @@ fn setup() -> (IWorldDispatcher, u128, Span<u128>, ISoldierSystemsDispatcher) {
         harbors, rivers, regions, wonder, order, caller_position.clone(),
     );
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let caller_id = caller_realm_entity_id;
     
@@ -387,7 +387,7 @@ fn test_merge_to_raider() {
 
 //     let (world, caller_id, new_units, soldier_systems_dispatcher) = setup();
 
-//     starknet::testing::set_contract_address(world.executor());
+//     
 //     set!(world, (
 //         EntityOwner {
 //             entity_id: *new_units.at(0),
@@ -417,9 +417,9 @@ fn test_merge_to_raider() {
 #[should_panic(expected: ('unit is travelling','ENTRYPOINT_FAILED' ))]
 fn test_travelling_unit() {
 
-    let (world, caller_id, new_units, soldier_systems_dispatcher) = setup();
+    let (world, _, new_units, soldier_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         ArrivalTime {
             entity_id: *new_units.at(0),

--- a/contracts/src/systems/config/contracts.cairo
+++ b/contracts/src/systems/config/contracts.cairo
@@ -36,7 +36,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl WorldConfigImpl of IWorldConfig<ContractState> {
         fn set_world_config(
             self: @ContractState,
@@ -53,7 +53,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl RealmFreeMintConfigImpl of IRealmFreeMintConfig<ContractState> {
         fn set_mint_config(
             self: @ContractState, world: IWorldDispatcher, resources: Span<(u8, u128)>
@@ -104,10 +104,11 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl MapConfigImpl of IMapConfig<ContractState> {
         fn set_exploration_config(
-            self: @ContractState, world: IWorldDispatcher, reward_resource_amount: u128
+            self: @ContractState, world: IWorldDispatcher, 
+            wheat_burn_amount: u128, fish_burn_amount: u128, reward_resource_amount: u128
         ) {
             assert_caller_is_admin(world);
 
@@ -115,6 +116,8 @@ mod config_systems {
                 world,
                 (MapExploreConfig {
                     config_id: WORLD_CONFIG_ID,
+                    wheat_burn_amount,
+                    fish_burn_amount,
                     reward_resource_amount
                 })
             );
@@ -122,7 +125,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CapacityConfigImpl of ICapacityConfig<ContractState> {
         fn set_capacity_config(
             self: @ContractState, world: IWorldDispatcher, entity_type: u128, weight_gram: u128
@@ -141,7 +144,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl WeightConfigImpl of IWeightConfig<ContractState> {
         fn set_weight_config(
             self: @ContractState, world: IWorldDispatcher, entity_type: u128, weight_gram: u128
@@ -160,7 +163,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TickConfigImpl of ITickConfig<ContractState> {
         fn set_tick_config(
             self: @ContractState,
@@ -182,7 +185,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CombatConfigImpl of ICombatConfig<ContractState> {
         fn set_combat_config(
             self: @ContractState,
@@ -293,7 +296,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl LevelingConfigImpl of ILevelingConfig<ContractState> {
         fn set_leveling_config(
             self: @ContractState,
@@ -386,7 +389,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl LaborConfigImpl of ILaborConfig<ContractState> {
         fn set_labor_cost_resources(
             self: @ContractState,
@@ -485,7 +488,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TransportConfigImpl of ITransportConfig<ContractState> {
         fn set_road_config(
             self: @ContractState,
@@ -551,7 +554,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HyperstructureConfigImpl of IHyperstructureConfig<ContractState> {
         fn create_hyperstructure(
             self: @ContractState,
@@ -618,7 +621,7 @@ mod config_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl BankConfigImpl of IBankConfig<ContractState> {
         fn create_bank(
             self: @ContractState,
@@ -740,7 +743,7 @@ mod config_systems {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl BuildingsConfigImpl of IBuildingsConfig<ContractState> {
         fn set_labor_buildings_config(
             self: @ContractState,

--- a/contracts/src/systems/config/interface.cairo
+++ b/contracts/src/systems/config/interface.cairo
@@ -210,7 +210,8 @@ trait IBuildingsConfig<TContractState> {
 #[starknet::interface]
 trait IMapConfig<TContractState> {
     fn set_exploration_config(
-        self: @TContractState, world: IWorldDispatcher, reward_resource_amount: u128
+        self: @TContractState, world: IWorldDispatcher, 
+        wheat_burn_amount: u128, fish_burn_amount: u128, reward_resource_amount: u128
     );
 }
 

--- a/contracts/src/systems/config/tests/bank_config_tests.cairo
+++ b/contracts/src/systems/config/tests/bank_config_tests.cairo
@@ -94,7 +94,7 @@ fn test_set_bank_auction() {
     };
 
     let caller = starknet::get_caller_address();
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let bank_id: u128 = 1;
     set!(world, Bank {

--- a/contracts/src/systems/config/tests/labor_config_tests/labor_auction_config_tests.cairo
+++ b/contracts/src/systems/config/tests/labor_config_tests/labor_auction_config_tests.cairo
@@ -25,7 +25,7 @@ fn test_set_labor_auction() {
         contract_address: config_systems_address
     };
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let zone: u8 = 5;
     let decay_constant: u128 = _0_1;

--- a/contracts/src/systems/hyperstructure/contracts.cairo
+++ b/contracts/src/systems/hyperstructure/contracts.cairo
@@ -13,7 +13,7 @@ mod hyperstructure_systems {
 
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HyperstructureSystemsImpl of IHyperstructureSystems<ContractState> {
 
         fn control(

--- a/contracts/src/systems/labor/contracts.cairo
+++ b/contracts/src/systems/labor/contracts.cairo
@@ -32,7 +32,7 @@ mod labor_systems {
 
     use eternum::constants::{REALM_LEVELING_CONFIG_ID, HYPERSTRUCTURE_LEVELING_CONFIG_ID};
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl LaborSystemsImpl of ILaborSystems<ContractState> {
         /// Builds labor for a particular resource on a realm
         ///
@@ -212,7 +212,7 @@ mod labor_systems {
 
             // generated labor
             // TODO: don't retrive labor_unharvested
-            let (labor_generated, is_complete, labor_unharvested) = labor.get_labor_generated(ts);
+            let (labor_generated, is_complete, _) = labor.get_labor_generated(ts);
 
             // assert base labor units not zero
             assert(labor_config.base_labor_units != 0, 'Base labor units cannot be zero');
@@ -351,9 +351,6 @@ mod labor_systems {
                 set!(world, (building));
             }
 
-            // Get Config
-            let labor_config: LaborConfig = get!(world, LABOR_CONFIG_ID, LaborConfig);
-
             // pay for labor 
             let labor_cost_resources = get!(world, resource_type, LaborCostResources);
             let labor_cost_resource_types: Span<u8> = unpack_resource_types(
@@ -369,7 +366,6 @@ mod labor_systems {
 
             assert(labor_auction.per_time_unit != 0, 'Labor auction not found');
 
-            let zero_fixed = Fixed { sign: false, mag: 0 };
 
             let mut index = 0_usize;
             loop {

--- a/contracts/src/systems/labor/tests/labor_build_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_build_tests.cairo
@@ -102,7 +102,7 @@ fn test_build_labor_non_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {
@@ -150,7 +150,7 @@ fn test_build_labor_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {
@@ -245,7 +245,7 @@ fn test_build_labor_after_completed() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {

--- a/contracts/src/systems/labor/tests/labor_harvest_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_harvest_tests.cairo
@@ -110,7 +110,7 @@ fn test_harvest_labor_non_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {
@@ -235,7 +235,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_non_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {
@@ -244,8 +244,6 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_non_food() {
             balance: 40
         }
     );
-
-    let hyperstructure_id = 1; //temp
 
     set!(world, (
         Level {
@@ -396,7 +394,7 @@ fn test_harvest_labor_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {
@@ -521,7 +519,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_food() {
     let labor_resource_type = get_labor_resource_type(resource_type);
 
     // switch to executor to set storage directly
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(
         world,
         Resource {

--- a/contracts/src/systems/labor/tests/labor_purchase_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_purchase_tests.cairo
@@ -36,7 +36,7 @@ fn setup(labor_cost_resource_type: u8) -> (IWorldDispatcher, u128, ILaborSystems
         contract_address: config_systems_address
     };
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set labor building config
     let buildingConfig = LaborBuildingsConfig {
@@ -55,7 +55,6 @@ fn setup(labor_cost_resource_type: u8) -> (IWorldDispatcher, u128, ILaborSystems
     set!(world, (buildingConfig));
 
     // set labor auction
-    let zone: u8 = 5;
     let decay_constant: u128 = _0_1;
     let per_time_unit: u128 = 50;
     let price_update_interval: u128 = 20;

--- a/contracts/src/systems/labor/utils.cairo
+++ b/contracts/src/systems/labor/utils.cairo
@@ -11,7 +11,7 @@ fn assert_harvestable_resource(resource_type: u8) {
 fn get_labor_resource_type(resource_type: u8) -> u8 {
     let is_food = (resource_type == ResourceTypes::FISH) | (resource_type == ResourceTypes::WHEAT);
 
-    let is_minable_resource = (resource_type > 0) & (resource_type <= 28);
+    // let is_minable_resource = (resource_type > 0) & (resource_type <= 28);
 
     let labor_resource_type: u8 = if is_food {
         resource_type - 3

--- a/contracts/src/systems/leveling/contracts.cairo
+++ b/contracts/src/systems/leveling/contracts.cairo
@@ -14,7 +14,7 @@ mod leveling_systems {
     use eternum::systems::leveling::contracts::leveling_systems::{InternalLevelingSystemsImpl as leveling};
     use eternum::systems::leveling::interface::ILevelingSystems;
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl LevelingSystemsImpl of ILevelingSystems<ContractState> {
 
         fn level_up_realm(

--- a/contracts/src/systems/leveling/tests/internal_leveling_tests.cairo
+++ b/contracts/src/systems/leveling/tests/internal_leveling_tests.cairo
@@ -79,7 +79,7 @@ mod internal_leveling_systems {
             ResourceTypes::STONE, ResourceTypes::COAL, ResourceTypes::COPPER,
             ResourceTypes::OBSIDIAN, ResourceTypes::SILVER,
         ];
-        starknet::testing::set_contract_address(world.executor());
+        
         loop {
             match resources.pop_front() {
                 Option::Some(resource_type) => {

--- a/contracts/src/systems/leveling/tests/realm_leveling_tests.cairo
+++ b/contracts/src/systems/leveling/tests/realm_leveling_tests.cairo
@@ -39,7 +39,7 @@ fn setup() -> (IWorldDispatcher, u128, ILevelingSystemsDispatcher) {
         contract_address: config_systems_address
     };
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set labor auction
     let decay_scaled: u128 = 1844674407370955161;

--- a/contracts/src/systems/name/contracts.cairo
+++ b/contracts/src/systems/name/contracts.cairo
@@ -5,7 +5,7 @@ mod name_systems {
     
     use traits::Into; 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl NameSystemsImpl of INameSystems<ContractState> {
         fn set_address_name(self: @ContractState, world: IWorldDispatcher, name: felt252) {
             let caller = starknet::get_caller_address();

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -27,7 +27,7 @@ mod realm_systems {
 
     use core::poseidon::poseidon_hash_span;
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl RealmSystemsImpl of IRealmSystems<ContractState> {
         fn create(
             self: @ContractState,

--- a/contracts/src/systems/resources/contracts.cairo
+++ b/contracts/src/systems/resources/contracts.cairo
@@ -44,7 +44,7 @@ use eternum::alias::ID;
         Transfer: Transfer,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ResourceSystemsImpl of IResourceSystems<ContractState> {
         
         /// Approve an entity to spend resources.
@@ -263,7 +263,6 @@ use eternum::alias::ID;
             ) -> bool {
             // ensure that receiver has enough weight capacity
             if entity_capacity.is_capped() {
-                let entity_id = entity_current_weight.entity_id;
                 entity_current_weight.value += additional_weight;
 
                 let can_carry 
@@ -287,7 +286,7 @@ use eternum::alias::ID;
 
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl InventorySystemsImpl of IInventorySystems<ContractState> {
 
 
@@ -599,9 +598,7 @@ use eternum::alias::ID;
             let mut entity_weight = get!(world, entity_id, Weight);
             let entity_capacity = get!(world, entity_id, Capacity); 
             let entity_quantity = get!(world, entity_id, Quantity);
-            let entity_total_capacity 
-                = entity_capacity.weight_gram * entity_quantity.get_value();
-            
+     
             let mut inventory = get!(world, entity_id, Inventory);
             assert(inventory.items_key != 0, 'entity has no inventory');
 
@@ -686,8 +683,6 @@ use eternum::alias::ID;
 
             let sender_id = sender_inventory.entity_id;
             let receiver_id = receiver_inventory.entity_id;
-
-            let sender_inventory_items_count = sender_inventory.items_count;
 
             let mut last_selected_index = sender_inventory.items_count;
             let mut sender_weight = get!(world, sender_id, Weight);

--- a/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
@@ -117,7 +117,7 @@ mod inventory_transfer_system_tests {
     #[available_gas(30000000000000)]
     fn test_inventory_transfer_item() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, chest_id, _, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
 
 
@@ -166,7 +166,7 @@ mod inventory_transfer_system_tests {
     #[available_gas(30000000000000)]
     fn test_inventory_transfer_item_to_self() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, chest_id, _, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
 
 
@@ -223,7 +223,7 @@ mod inventory_transfer_system_tests {
     #[should_panic(expected: ('not caravan owner','ENTRYPOINT_FAILED' ))]
     fn test_inventory_transfer_item_not_transport_owner() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, _, _, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
 
         // set caller to arbitrary address
@@ -244,7 +244,7 @@ mod inventory_transfer_system_tests {
     #[should_panic(expected: ('mismatched positions','ENTRYPOINT_FAILED' ))]
     fn test_inventory_transfer_item_wrong_position() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, _,_, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
 
         // receiver is not in the same position as donor transport
@@ -278,7 +278,7 @@ mod inventory_transfer_system_tests {
     #[should_panic(expected: ('transport has not arrived','ENTRYPOINT_FAILED' ))]
     fn test_inventory_transfer_item_wrong_arrival_time() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, _, _, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
 
         // receiver is not in the same position as donor transport
@@ -305,7 +305,7 @@ mod inventory_transfer_system_tests {
     #[should_panic(expected: ('inventory is empty','ENTRYPOINT_FAILED' ))]
     fn test_inventory_transfer_item_from_empty_inventory() {
 
-        let (world, chest_id, donor_id, donor_transport_id, inventory_systems_dispatcher) 
+        let (world, _, _, donor_transport_id, inventory_systems_dispatcher) 
             = setup();
         starknet::testing::set_contract_address(
             contract_address_const::<'donor'>()

--- a/contracts/src/systems/resources/tests/resource_approval_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/resource_approval_system_tests.cairo
@@ -45,7 +45,7 @@ mod resource_approval_system_tests {
     fn make_owner_and_receiver(
         world: IWorldDispatcher, owner_entity_id: u64, receiver_entity_id: u64
     ) {
-        starknet::testing::set_contract_address(world.executor());
+        
 
         let owner_entity_position = Position { 
             x: 100_000, 
@@ -107,7 +107,7 @@ mod resource_approval_system_tests {
         );
 
         let approved_entity_id = 13_u64;
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Owner { 
                 address: contract_address_const::<'approved_entity'>(), 
@@ -157,7 +157,7 @@ mod resource_approval_system_tests {
         );
 
         let approved_entity_id = 13_u64;
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Owner { 
                 address: contract_address_const::<'approved_entity'>(), 
@@ -207,7 +207,7 @@ mod resource_approval_system_tests {
         );
 
         let approved_entity_id = 13_u64;
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Owner { 
                 address: contract_address_const::<'approved_entity'>(), 

--- a/contracts/src/systems/resources/tests/resource_transfer_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/resource_transfer_system_tests.cairo
@@ -69,7 +69,7 @@ mod resource_transfer_system_tests {
     fn make_owner_and_receiver(
         world: IWorldDispatcher, sender_entity_id: u64, receiver_entity_id: u64
     ) {
-        starknet::testing::set_contract_address(world.executor());
+        
 
         let sender_entity_position = Position { 
             x: 100_000, 
@@ -186,7 +186,7 @@ mod resource_transfer_system_tests {
             world, sender_entity_id, receiver_entity_id
         );
 
-        starknet::testing::set_contract_address(world.executor());
+        
 
         // set receiving entity capacity, and weight config 
         set!(world, (
@@ -263,7 +263,7 @@ mod resource_transfer_system_tests {
         let (world, resource_systems_dispatcher) = setup();
 
         // call as executor
-        starknet::testing::set_contract_address(world.executor());
+        
         
         
         let sender_entity_id = 11_u64;
@@ -361,7 +361,7 @@ mod resource_transfer_system_tests {
         );
 
         let approved_entity_id = 13_u64;
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Owner { 
                 address: contract_address_const::<'approved_entity'>(), 
@@ -447,7 +447,7 @@ mod resource_transfer_system_tests {
         );
 
         let approved_entity_id = 13_u64;
-        starknet::testing::set_contract_address(world.executor());
+        
         set!(world, (
             Owner { 
                 address: contract_address_const::<'approved_entity'>(), 

--- a/contracts/src/systems/test/contracts/resource.cairo
+++ b/contracts/src/systems/test/contracts/resource.cairo
@@ -6,7 +6,7 @@ mod test_resource_systems {
     use eternum::constants::ResourceTypes;
     use eternum::alias::ID;
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ResourceSystemsImpl of IResourceSystems<ContractState> {
         fn mint(
             self: @ContractState,

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -52,7 +52,7 @@ mod trade_systems {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TradeSystemsImpl of ITradeSystems<ContractState> {
 
         fn create_order(

--- a/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
@@ -152,7 +152,7 @@ fn setup(direct_trade: bool) -> (IWorldDispatcher, u128, u128, u128, u128, ITrad
     );
 
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let maker_id = maker_realm_entity_id;
     let taker_id = taker_realm_entity_id;
@@ -210,7 +210,7 @@ fn setup(direct_trade: bool) -> (IWorldDispatcher, u128, u128, u128, u128, ITrad
     
     // create order
     starknet::testing::set_contract_address(contract_address_const::<'maker'>());
-    let trade_taker_id = if direct_trade {
+    if direct_trade {
         taker_id
     } else {
         0
@@ -273,7 +273,7 @@ fn test_accept_without_taker_transport_id() {
         = setup(false);
 
     // let maker and taker be at the same location
-    starknet::testing::set_contract_address(world.executor());
+    
     let maker_position = get!(world, maker_id, Position);
     set!(world, (
         Position {
@@ -345,7 +345,7 @@ fn test_accept_without_taker_transport_id() {
 fn test_accept_without_taker_transport_id_wrong_position() {
     // when there is no provided taker_tansport_id, 
     // maker and taker must be in the same position
-    let (world, trade_id, maker_id, taker_id, _, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, _, trade_systems_dispatcher) 
         = setup(false);
 
     // accept order 
@@ -670,7 +670,7 @@ fn test_accept_order_with_realm_travel_bonus() {
         = setup(true);
 
     let caller_address = starknet::get_contract_address();
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set maker and taker levels
     set!(world, (
@@ -863,7 +863,7 @@ fn test_accept_order_with_realm_and_order_travel_bonus() {
         = setup(true);
 
     let caller_address = starknet::get_contract_address();
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set maker and taker realm level
     set!(world, (
@@ -1115,14 +1115,14 @@ fn test_accept_order_with_road() {
 fn test_not_trade_taker_id() {
 
 
-    let (world, trade_id, maker_id, taker_id, taker_transport_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, _, taker_transport_id, trade_systems_dispatcher) 
         = setup(true);
     
     // the setup states the trade is a direct offer
     // so here we are checking to see that the person 
     // who wants to accept is the intended recepient
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let taker_id = 9999; // set arbitrarily
     set!(world, (
@@ -1148,7 +1148,7 @@ fn test_not_trade_taker_id() {
 #[should_panic(expected: ('not owned by caller', 'ENTRYPOINT_FAILED' ))]
 fn test_caller_not_taker() {
 
-    let (world, trade_id, maker_id, taker_id, taker_transport_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, taker_transport_id, trade_systems_dispatcher) 
         = setup(true);
 
     // create order with a caller that isnt the owner of taker_id
@@ -1167,7 +1167,7 @@ fn test_caller_not_taker() {
 #[should_panic(expected: ('not caravan owner', 'ENTRYPOINT_FAILED' ))]
 fn test_caller_not_owner_of_transport_id() {
 
-    let (world, trade_id, maker_id, taker_id, taker_transport_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, _, trade_systems_dispatcher) 
         = setup(true);
 
     let taker_transport_id = 9999; // set arbitrarily
@@ -1187,11 +1187,11 @@ fn test_caller_not_owner_of_transport_id() {
 #[should_panic(expected: ('mismatched positions', 'ENTRYPOINT_FAILED' ))]
 fn test_different_transport_position() {
 
-    let (world, trade_id, maker_id, taker_id, taker_transport_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, taker_transport_id, trade_systems_dispatcher) 
         = setup(true);
 
     // set an arbitrary position
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, Position {
         entity_id: taker_id,
         x: 999,
@@ -1215,12 +1215,12 @@ fn test_different_transport_position() {
 #[should_panic(expected: ('transport has not arrived', 'ENTRYPOINT_FAILED' ))]
 fn test_transport_in_transit() {
 
-    let (world, trade_id, maker_id, taker_id, taker_transport_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, taker_transport_id, trade_systems_dispatcher) 
         = setup(true);
 
 
     // set arrival time to some time in future
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, ArrivalTime {
         entity_id: taker_transport_id,
         arrives_at: starknet::get_block_timestamp() + 40
@@ -1241,7 +1241,7 @@ fn test_transport_in_transit() {
 #[should_panic(expected: ('not enough capacity', 'ENTRYPOINT_FAILED' ))]
 fn test_transport_not_enough_capacity() {
 
-    let (world, trade_id, maker_id, taker_id, _, trade_systems_dispatcher) 
+    let (world, trade_id, _, taker_id, _, trade_systems_dispatcher) 
         = setup(true);
 
     //          note

--- a/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
@@ -135,7 +135,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     );
 
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let maker_id = maker_realm_entity_id;
     let taker_id = taker_realm_entity_id;
@@ -222,7 +222,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
 #[available_gas(3000000000000)]
 fn test_cancel() {
 
-    let (world, trade_id, maker_id, taker_id, trade_systems_dispatcher) 
+    let (world, trade_id, maker_id, _, trade_systems_dispatcher) 
         = setup();
 
 
@@ -264,11 +264,11 @@ fn test_cancel() {
 #[should_panic(expected: ('trade must be open', 'ENTRYPOINT_FAILED' ))]
 fn test_cancel_after_acceptance() {
 
-    let (world, trade_id, maker_id, taker_id, trade_systems_dispatcher) 
+    let (world, trade_id,_, _, trade_systems_dispatcher) 
         = setup();
 
     // accept order 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
             Status {
                 trade_id,
@@ -285,7 +285,7 @@ fn test_cancel_after_acceptance() {
         .cancel_order(world, trade_id);
 
 }
-
+ 
 
 
 #[test]
@@ -293,7 +293,7 @@ fn test_cancel_after_acceptance() {
 #[should_panic(expected: ('caller must be trade maker', 'ENTRYPOINT_FAILED' ))]
 fn test_cancel_caller_not_maker() {
 
-    let (world, trade_id, maker_id, taker_id, trade_systems_dispatcher) 
+    let (world, trade_id, _, _, trade_systems_dispatcher) 
         = setup();
 
     // set caller to an unknown address

--- a/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
@@ -103,7 +103,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     );
 
 
-    starknet::testing::set_contract_address(world.executor());
+    
 
     let maker_id = realm_entity_id;
     let taker_id = 12_u128;
@@ -257,7 +257,7 @@ fn test_caller_not_maker() {
     starknet::testing::set_contract_address(
         contract_address_const::<'some_unknown'>()
     );
-    let trade_id = trade_systems_dispatcher.create_order(
+    trade_systems_dispatcher.create_order(
             world,
             maker_id,
             array![
@@ -279,7 +279,7 @@ fn test_caller_not_maker() {
 #[available_gas(3000000000000)]
 #[should_panic(expected: ('not caravan owner', 'ENTRYPOINT_FAILED' ))]
 fn test_caller_not_owner_of_transport_id() {
-    let (world, maker_id, maker_transport_id, taker_id,trade_systems_dispatcher) 
+    let (world, maker_id, _, taker_id,trade_systems_dispatcher) 
         = setup();
     
     let maker_transport_id = 99999; // set some arbitray value
@@ -287,7 +287,7 @@ fn test_caller_not_owner_of_transport_id() {
     starknet::testing::set_contract_address(
         contract_address_const::<'maker'>()
     );
-    let trade_id = trade_systems_dispatcher.create_order(
+    trade_systems_dispatcher.create_order(
             world,
             maker_id,
             array![
@@ -313,7 +313,7 @@ fn test_different_transport_position() {
         = setup();
 
     // set an arbitrary position
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, Position {
         entity_id: maker_id,
         x: 999,
@@ -324,7 +324,7 @@ fn test_different_transport_position() {
     starknet::testing::set_contract_address(
         contract_address_const::<'maker'>()
     );
-    let trade_id = trade_systems_dispatcher.create_order(
+    trade_systems_dispatcher.create_order(
             world,
             maker_id,
             array![
@@ -351,7 +351,7 @@ fn test_transport_in_transit() {
         = setup();
 
     // set arrival time to some time in future
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, ArrivalTime {
         entity_id: maker_transport_id,
         arrives_at: starknet::get_block_timestamp() + 40
@@ -361,7 +361,7 @@ fn test_transport_in_transit() {
     starknet::testing::set_contract_address(
         contract_address_const::<'maker'>()
     );
-    let trade_id = trade_systems_dispatcher.create_order(
+    trade_systems_dispatcher.create_order(
             world,
             maker_id,
             array![
@@ -436,7 +436,7 @@ fn test_transport_not_enough_capacity() {
         = caravan_systems_dispatcher.create(world, maker_transport_units);
 
     
-    let trade_id = trade_systems_dispatcher.create_order(
+    trade_systems_dispatcher.create_order(
             world,
             maker_id,
             array![

--- a/contracts/src/systems/transport/contracts/caravan_systems.cairo
+++ b/contracts/src/systems/transport/contracts/caravan_systems.cairo
@@ -29,7 +29,7 @@ mod caravan_systems {
     use core::poseidon::poseidon_hash_span;
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl CaravanSystemsImpl of ICaravanSystems<ContractState>{
         /// Create a caravan entity
         ///

--- a/contracts/src/systems/transport/contracts/road_systems.cairo
+++ b/contracts/src/systems/transport/contracts/road_systems.cairo
@@ -13,7 +13,7 @@ mod road_systems {
     };
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl RoadSystemsImpl of IRoadSystems<ContractState> {
 
         /// Create a road between two coordinates on the map.

--- a/contracts/src/systems/transport/contracts/transport_unit_systems.cairo
+++ b/contracts/src/systems/transport/contracts/transport_unit_systems.cairo
@@ -22,7 +22,7 @@ mod transport_unit_systems {
 
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TransportUnitSystemsImpl of ITransportUnitSystems<ContractState>{
 
         /// Creates a new free transport unit.

--- a/contracts/src/systems/transport/contracts/travel_systems.cairo
+++ b/contracts/src/systems/transport/contracts/travel_systems.cairo
@@ -41,7 +41,7 @@ mod travel_systems {
         Travel: Travel,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TravelSystemsImpl of ITravelSystems<ContractState> {
 
         /// Travel to a destination

--- a/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
@@ -183,7 +183,7 @@ fn test_create_caravan() {
 #[should_panic(expected: ('entity is not owned by caller','ENTRYPOINT_FAILED' ))]
 fn test_create_caravan__not_owner() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -196,7 +196,7 @@ fn test_create_caravan__not_owner() {
 #[available_gas(300000000000)]
 #[should_panic(expected: ('entity is blocked','ENTRYPOINT_FAILED' ))]
 fn test_create_caravan__blocked_entity() {
-    let (world, mut transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, mut transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     
@@ -228,7 +228,7 @@ fn test_create_caravan__blocked_entity() {
 #[available_gas(300000000000)]
 fn test_disassemble_caravan() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -295,7 +295,7 @@ fn test_disassemble_caravan() {
 #[should_panic(expected: ('caller not owner','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__caller_not_owner() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -305,8 +305,7 @@ fn test_disassemble_caravan__caller_not_owner() {
 
     // disassemble caravan
     starknet::testing::set_contract_address(contract_address_const::<0x99>());
-    let disassembled_transport_ids 
-        = caravan_systems_dispatcher.disassemble(world, caravan_id);
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
 }
 
 
@@ -317,7 +316,7 @@ fn test_disassemble_caravan__caller_not_owner() {
 #[should_panic(expected: ('not a caravan','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__not_caravan() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, _, caravan_systems_dispatcher, _) 
         = setup();
     
     let caravan_id = 0x1234567890; // fictituous id
@@ -332,7 +331,7 @@ fn test_disassemble_caravan__not_caravan() {
 #[should_panic(expected: ('inventory not empty','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__non_empty_inventory() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -340,7 +339,7 @@ fn test_disassemble_caravan__non_empty_inventory() {
         = caravan_systems_dispatcher.create(world, transport_units.clone());
 
     // add item to inventory
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut inventory = get!(world, caravan_id, Inventory);
     inventory.items_count = 1;
     set!(world, (inventory));
@@ -356,7 +355,7 @@ fn test_disassemble_caravan__non_empty_inventory() {
 #[should_panic(expected: ('caravan is blocked','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__blocked_caravan() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -364,7 +363,7 @@ fn test_disassemble_caravan__blocked_caravan() {
         = caravan_systems_dispatcher.create(world, transport_units.clone());
 
     // block caravan
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut movable = get!(world, caravan_id, Movable);
     movable.blocked = true;
     set!(world, (movable));
@@ -380,7 +379,7 @@ fn test_disassemble_caravan__blocked_caravan() {
 #[should_panic(expected: ('caravan in transit','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__caravan_in_transit() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -388,7 +387,7 @@ fn test_disassemble_caravan__caravan_in_transit() {
         = caravan_systems_dispatcher.create(world, transport_units.clone());
 
     // update arrival time
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut arrival_time = get!(world, caravan_id, ArrivalTime);
     arrival_time.arrives_at = 1;
     set!(world, (arrival_time));
@@ -404,7 +403,7 @@ fn test_disassemble_caravan__caravan_in_transit() {
 #[should_panic(expected: ('mismatched positions','ENTRYPOINT_FAILED' ))]
 fn test_disassemble_caravan__not_at_realm() {
 
-    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+    let (world, transport_units, caravan_systems_dispatcher, _) 
         = setup();
     
     // create caravan
@@ -412,7 +411,7 @@ fn test_disassemble_caravan__not_at_realm() {
         = caravan_systems_dispatcher.create(world, transport_units.clone());
 
     // update position
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut position = get!(world, caravan_id, Position);
     position.x = 1;
     set!(world, (position));

--- a/contracts/src/systems/transport/tests/road_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/road_systems_tests.cairo
@@ -49,7 +49,7 @@ fn test_create() {
 
     let entity_id: u128 = 44;
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, ( 
         Owner { 
             entity_id: entity_id, 
@@ -102,7 +102,7 @@ fn test_create() {
 fn test_not_entity() {
     let (world, road_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     let entity_id: u128 = 44;
     let start_coord = Coord { x: 20, y: 30};
     let end_coord = Coord { x: 40, y: 50};
@@ -141,7 +141,7 @@ fn test_insufficient_balance() {
 
     let entity_id: u128 = 44;
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, ( 
         Owner { entity_id: entity_id, address: contract_address_const::<'entity'>()},
         Resource {
@@ -186,7 +186,7 @@ fn test_insufficient_balance() {
 fn test_already_exists() {
     let (world, road_systems_dispatcher) = setup();
 
-    starknet::testing::set_contract_address(world.executor());
+    
     let entity_id: u128 = 44;
     let start_coord = Coord { x: 20, y: 30};
     let end_coord = Coord { x: 40, y: 50};

--- a/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
@@ -199,8 +199,7 @@ fn test_return_free_transport_unit() {
         = transport_unit_systems_dispatcher.create_free_unit(
             world, realm_entity_id, 10
         );
-    let free_transport_unit_id_2
-        = transport_unit_systems_dispatcher.create_free_unit(
+    transport_unit_systems_dispatcher.create_free_unit(
             world, realm_entity_id, 10
         );
 
@@ -218,7 +217,7 @@ fn test_return_free_transport_unit() {
     
 
     // check that the free transport unit 1 has been returned
-    let (quantity, position, metadata, owner, capacity, movable, arrival_time) 
+    let (quantity, position, metadata, owner, capacity, movable, _) 
     = get!(world, free_transport_unit_id_1, (Quantity, Position, EntityMetadata, Owner, Capacity, Movable, ArrivalTime));
 
     assert(quantity.value == 0, 'unit not returnd');
@@ -255,7 +254,7 @@ fn test_return__wrong_unit_type() {
 
     
     // set the entity type to 0
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut metadata = get!(world, free_transport_unit_id, EntityMetadata);
     metadata.entity_type = 0;
     set!(world, (metadata));
@@ -306,7 +305,7 @@ fn test_return__movable_blocked() {
         );
 
     // set the unit as blocked
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut unit_movable = get!(world, free_transport_unit_id, Movable);
     unit_movable.blocked = true;
     set!(world, (unit_movable));
@@ -336,7 +335,7 @@ fn test_return__no_quantity() {
         );
 
     // set the quantity to 0
-    starknet::testing::set_contract_address(world.executor());
+    
     let mut unit_quantity = get!(world, free_transport_unit_id, Quantity);
     unit_quantity.value = 0;
     set!(world, (unit_quantity));

--- a/contracts/src/systems/transport/tests/travel_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/travel_systems_tests.cairo
@@ -43,7 +43,7 @@ fn setup() -> (IWorldDispatcher, u64, Position, Coord, ITravelSystemsDispatcher)
     let world = spawn_eternum();
 
     // set as executor
-    starknet::testing::set_contract_address(world.executor());
+    
 
 
     let travelling_entity_id = 11_u64;
@@ -104,6 +104,8 @@ fn test_travel() {
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0,          
         }
@@ -145,7 +147,7 @@ fn test_travel_with_realm_bonus() {
     ///////////////////////////////
 
     let realm_entity_id = 99;
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         EntityOwner {
             entity_id: travelling_entity_id.into(),
@@ -192,6 +194,8 @@ fn test_travel_with_realm_bonus() {
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0,          
         }
@@ -233,7 +237,7 @@ fn test_travel_with_realm_and_order_bonus() {
 
     let realm_entity_id = 99;
     let realm_order_id: u8 = 1;
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         EntityOwner {
             entity_id: travelling_entity_id.into(),
@@ -279,7 +283,7 @@ fn test_travel_with_realm_and_order_bonus() {
     //  set order level
     ///////////////////////////////////////
 
-    starknet::testing::set_contract_address(world.executor());
+    
     set!(world, (
         EntityOwner {
             entity_id: travelling_entity_id.into(),
@@ -297,6 +301,8 @@ fn test_travel_with_realm_and_order_bonus() {
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0,          
         }
@@ -359,6 +365,8 @@ fn test_travel_with_road(){
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0  
         }
@@ -449,6 +457,8 @@ fn test_blocked() {
             sec_per_km: 10,
             blocked: true,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0,  
         }
@@ -480,7 +490,9 @@ fn test_in_transit() {
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
-              intermediate_coord_x: 0,  
+            start_coord_x: 0,
+            start_coord_y: 0,
+            intermediate_coord_x: 0,  
             intermediate_coord_y: 0,  
         },
         ArrivalTime {
@@ -527,7 +539,7 @@ fn setup_hex_travel() -> (IWorldDispatcher, u64, Position, ITravelSystemsDispatc
     let world = spawn_eternum();
 
     // set as executor
-    starknet::testing::set_contract_address(world.executor());
+    
 
     // set tick config
     let tick_config = TickConfig {
@@ -565,6 +577,8 @@ fn setup_hex_travel() -> (IWorldDispatcher, u64, Position, ITravelSystemsDispatc
             sec_per_km: 10,
             blocked: false,
             round_trip: false,
+            start_coord_x: 0,
+            start_coord_y: 0,
             intermediate_coord_x: 0,  
             intermediate_coord_y: 0,  
         })
@@ -657,7 +671,7 @@ fn test_travel_hex__destination_tile_not_explored() {
 
     let (
         world, travelling_entity_id,
-         travelling_entity_position, travel_systems_dispatcher
+         _, travel_systems_dispatcher
     ) = setup_hex_travel();
 
     let travel_directions = array![Direction::East].span();
@@ -687,8 +701,10 @@ fn test_travel_hex__exceed_max_tick_moves() {
         Direction::East, Direction::East 
     ].span();
     let current_coord: Coord = travelling_entity_position.into();
-    let destination_coord: Coord 
-        = get_and_explore_destination_tiles(world, current_coord, travel_directions);
+    // explore destination coord
+    get_and_explore_destination_tiles(
+        world, current_coord, travel_directions
+    );
 
 
     // travelling entity travels

--- a/contracts/src/utils/map/biomes.cairo
+++ b/contracts/src/utils/map/biomes.cairo
@@ -240,6 +240,6 @@ mod tests {
 
     #[test]
     fn test_noisy() {
-        let x = get_biome(1128, 389);
+        get_biome(1128, 389);
     }
 }


### PR DESCRIPTION
- fix compilation warnings related to this codebase. this doesn't suppress warnings from codebases used as dependencies